### PR TITLE
bridge_windows.go private to public

### DIFF
--- a/varlink/bridge_windows.go
+++ b/varlink/bridge_windows.go
@@ -44,8 +44,8 @@ func NewBridge(bridge string) (*Connection, error) {
 	}
 	c.conn = PipeCon{nil, cmd, &r, &w}
 	c.address = ""
-	c.reader = bufio.NewReader(r)
-	c.writer = bufio.NewWriter(w)
+	c.Reader = bufio.NewReader(r)
+	c.Writer = bufio.NewWriter(w)
 
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
Like 3ac79db6fd6aec70924193b090962f92985fe199, just need to tidy up the
references to the reader and writer to account for the change to being
public.

Signed-off-by: baude <bbaude@redhat.com>