### PR TITLE
Add context support

### DIFF
--- a/cmd/varlink-go-certification/main.go
+++ b/cmd/varlink-go-certification/main.go
@@ -1,99 +1,103 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification"
-	"github.com/varlink/go/varlink"
 	"io"
 	"math"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification"
+	"github.com/varlink/go/varlink"
 )
 
-func run_client(address string) {
-	c, err := varlink.NewConnection(address)
+func run_client(ctx context.Context, address string) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, err := varlink.NewConnection(ctx, address)
 	if err != nil {
 		fmt.Println("Failed to connect")
 		return
 	}
 	defer c.Close()
 
-	client_id, err := orgvarlinkcertification.Start().Call(c)
+	client_id, err := orgvarlinkcertification.Start().Call(ctx, c)
 	if err != nil {
 		fmt.Println("Start() failed")
 		return
 	}
 	fmt.Printf("Start: '%v'\n", client_id)
 
-	b1, err := orgvarlinkcertification.Test01().Call(c, client_id)
+	b1, err := orgvarlinkcertification.Test01().Call(ctx, c, client_id)
 	if err != nil {
 		fmt.Println("Test01() failed")
 		return
 	}
 	fmt.Printf("Test01: '%v'\n", b1)
 
-	i2, err := orgvarlinkcertification.Test02().Call(c, client_id, b1)
+	i2, err := orgvarlinkcertification.Test02().Call(ctx, c, client_id, b1)
 	if err != nil {
 		fmt.Println("Test02() failed")
 		return
 	}
 	fmt.Printf("Test02: '%v'\n", i2)
 
-	f3, err := orgvarlinkcertification.Test03().Call(c, client_id, i2)
+	f3, err := orgvarlinkcertification.Test03().Call(ctx, c, client_id, i2)
 	if err != nil {
 		fmt.Println("Test03() failed")
 		return
 	}
 	fmt.Printf("Test03: '%v'\n", f3)
 
-	s4, err := orgvarlinkcertification.Test04().Call(c, client_id, f3)
+	s4, err := orgvarlinkcertification.Test04().Call(ctx, c, client_id, f3)
 	if err != nil {
 		fmt.Println("Test04() failed")
 		return
 	}
 	fmt.Printf("Test04: '%v'\n", s4)
 
-	b5, i5, f5, s5, err := orgvarlinkcertification.Test05().Call(c, client_id, s4)
+	b5, i5, f5, s5, err := orgvarlinkcertification.Test05().Call(ctx, c, client_id, s4)
 	if err != nil {
 		fmt.Println("Test05() failed")
 		return
 	}
 	fmt.Printf("Test05: '%v'\n", b5)
 
-	o6, err := orgvarlinkcertification.Test06().Call(c, client_id, b5, i5, f5, s5)
+	o6, err := orgvarlinkcertification.Test06().Call(ctx, c, client_id, b5, i5, f5, s5)
 	if err != nil {
 		fmt.Println("Test06() failed")
 		return
 	}
 	fmt.Printf("Test06: '%v'\n", o6)
 
-	m7, err := orgvarlinkcertification.Test07().Call(c, client_id, o6)
+	m7, err := orgvarlinkcertification.Test07().Call(ctx, c, client_id, o6)
 	if err != nil {
 		fmt.Println("Test07() failed")
 		return
 	}
 	fmt.Printf("Test07: '%v'\n", m7)
 
-	m8, err := orgvarlinkcertification.Test08().Call(c, client_id, m7)
+	m8, err := orgvarlinkcertification.Test08().Call(ctx, c, client_id, m7)
 	if err != nil {
 		fmt.Println("Test08() failed")
 		return
 	}
 	fmt.Printf("Test08: '%v'\n", m8)
 
-	t9, err := orgvarlinkcertification.Test09().Call(c, client_id, m8)
+	t9, err := orgvarlinkcertification.Test09().Call(ctx, c, client_id, m8)
 	if err != nil {
 		fmt.Println("Test09() failed")
 		return
 	}
 	fmt.Printf("Test09: '%v'\n", t9)
 
-	receive10, err := orgvarlinkcertification.Test10().Send(c, varlink.More, client_id, t9)
+	receive10, err := orgvarlinkcertification.Test10().Send(ctx, c, varlink.More, client_id, t9)
 	if err != nil {
 		fmt.Println("Test10() failed")
 		return
@@ -102,7 +106,7 @@ func run_client(address string) {
 	fmt.Println("Test10() Send:")
 	var a10 []string
 	for {
-		s10, flags10, err := receive10()
+		s10, flags10, err := receive10(ctx)
 		if err != nil {
 			fmt.Println("Test10() receive failed")
 			return
@@ -116,14 +120,14 @@ func run_client(address string) {
 	}
 	fmt.Printf("Test10: '%v'\n", a10)
 
-	_, err = orgvarlinkcertification.Test11().Send(c, varlink.Oneway, client_id, a10)
+	_, err = orgvarlinkcertification.Test11().Send(ctx, c, varlink.Oneway, client_id, a10)
 	if err != nil {
 		fmt.Println("Test11() failed")
 		return
 	}
 	fmt.Println("Test11: ''")
 
-	end, err := orgvarlinkcertification.End().Call(c, client_id)
+	end, err := orgvarlinkcertification.End().Call(ctx, c, client_id)
 	if err != nil {
 		fmt.Println("End() failed")
 		return
@@ -187,84 +191,84 @@ func (t *test) RemoveClient(id string) {
 	delete(t.clients, id)
 }
 
-func (t *test) Start(c orgvarlinkcertification.VarlinkCall) error {
-	return c.ReplyStart(t.NewClient().id)
+func (t *test) Start(ctx context.Context, c orgvarlinkcertification.VarlinkCall) error {
+	return c.ReplyStart(ctx, t.NewClient().id)
 }
 
-func (t *test) Test01(c orgvarlinkcertification.VarlinkCall, client_id_ string) error {
+func (t *test) Test01(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
-	return c.ReplyTest01(true)
+	return c.ReplyTest01(ctx, true)
 }
 
-func (t *test) Test02(c orgvarlinkcertification.VarlinkCall, client_id_ string, bool_ bool) error {
+func (t *test) Test02(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, bool_ bool) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if !bool_ {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
-	return c.ReplyTest02(1)
+	return c.ReplyTest02(ctx, 1)
 }
 
-func (t *test) Test03(c orgvarlinkcertification.VarlinkCall, client_id_ string, int_ int64) error {
+func (t *test) Test03(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, int_ int64) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if int_ != 1 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
-	return c.ReplyTest03(1.0)
+	return c.ReplyTest03(ctx, 1.0)
 }
 
-func (t *test) Test04(c orgvarlinkcertification.VarlinkCall, client_id_ string, float_ float64) error {
+func (t *test) Test04(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, float_ float64) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if float_ != 1.0 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
-	return c.ReplyTest04("ping")
+	return c.ReplyTest04(ctx, "ping")
 }
-func (t *test) Test05(c orgvarlinkcertification.VarlinkCall, client_id_ string, string_ string) error {
+func (t *test) Test05(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, string_ string) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if string_ != "ping" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
-	return c.ReplyTest05(false, 2, math.Pi, "a lot of string")
+	return c.ReplyTest05(ctx, false, 2, math.Pi, "a lot of string")
 }
 
-func (t *test) Test06(c orgvarlinkcertification.VarlinkCall, client_id_ string, bool_ bool, int_ int64, float_ float64, string_ string) error {
+func (t *test) Test06(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, bool_ bool, int_ int64, float_ float64, string_ string) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if bool_ {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if int_ != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if float_ != math.Pi {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if string_ != "a lot of string" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	s := struct {
@@ -278,57 +282,57 @@ func (t *test) Test06(c orgvarlinkcertification.VarlinkCall, client_id_ string, 
 		Float:  math.Pi,
 		String: "a lot of string",
 	}
-	return c.ReplyTest06(s)
+	return c.ReplyTest06(ctx, s)
 }
 
-func (t *test) Test07(c orgvarlinkcertification.VarlinkCall, client_id_ string, struct_ struct {
+func (t *test) Test07(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, struct_ struct {
 	Bool   bool
 	Int    int64
 	Float  float64
 	String string
 }) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if struct_.Bool {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if struct_.Int != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if struct_.Float != math.Pi {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if struct_.String != "a lot of string" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	m := map[string]string{
 		"bar": "Bar",
 		"foo": "Foo",
 	}
-	return c.ReplyTest07(m)
+	return c.ReplyTest07(ctx, m)
 }
 
-func (t *test) Test08(c orgvarlinkcertification.VarlinkCall, client_id_ string, map_ map[string]string) error {
+func (t *test) Test08(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, map_ map[string]string) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if len(map_) != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if map_["bar"] != "Bar" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if map_["foo"] != "Foo" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	m := map[string]struct{}{
@@ -336,31 +340,31 @@ func (t *test) Test08(c orgvarlinkcertification.VarlinkCall, client_id_ string, 
 		"two":   {},
 		"three": {},
 	}
-	return c.ReplyTest08(m)
+	return c.ReplyTest08(ctx, m)
 }
 
-func (t *test) Test09(c orgvarlinkcertification.VarlinkCall, client_id_ string, set_ map[string]struct{}) error {
+func (t *test) Test09(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, set_ map[string]struct{}) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if len(set_) != 3 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	_, ok := set_["one"]
 	if !ok {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	_, ok = set_["two"]
 	if !ok {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	_, ok = set_["three"]
 	if !ok {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	m := orgvarlinkcertification.MyType{
@@ -388,12 +392,12 @@ func (t *test) Test09(c orgvarlinkcertification.VarlinkCall, client_id_ string, 
 			}{Foo: true, Bar: false},
 		},
 	}
-	return c.ReplyTest09(m)
+	return c.ReplyTest09(ctx, m)
 }
 
-func (t *test) Test10(c orgvarlinkcertification.VarlinkCall, client_id_ string, mytype_ orgvarlinkcertification.MyType) error {
+func (t *test) Test10(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, mytype_ orgvarlinkcertification.MyType) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	var o struct {
@@ -408,132 +412,132 @@ func (t *test) Test10(c orgvarlinkcertification.VarlinkCall, client_id_ string, 
 	}
 
 	if o.Method != "org.varlink.certification.Test09" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if len(o.Parameters.Map) != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if o.Parameters.Map["bar"] != "Bar" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if o.Parameters.Map["foo"] != "Foo" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Enum != "two" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Struct.First != 1 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Struct.Second != "2" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if len(mytype_.Array) != 3 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Array[0] != "one" && mytype_.Array[1] != "two" && mytype_.Array[2] != "three" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if len(mytype_.Dictionary) != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Dictionary["bar"] != "Bar" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Dictionary["foo"] != "Foo" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if len(mytype_.Stringset) != 3 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	_, ok := mytype_.Stringset["one"]
 	if !ok {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	_, ok = mytype_.Stringset["two"]
 	if !ok {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	_, ok = mytype_.Stringset["three"]
 	if !ok {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Nullable != nil {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Nullable_array_struct != nil {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	i := *mytype_.Interface.Foo
 	if len(i) != 4 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if i[0] != nil {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if len(*i[1]) != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if (*i[1])["Foo"] != "foo" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if (*i[1])["Bar"] != "bar" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if i[2] != nil {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if len(*i[3]) != 2 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if (*i[3])["one"] != "foo" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if (*i[3])["two"] != "bar" {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if !mytype_.Interface.Anon.Foo {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if mytype_.Interface.Anon.Bar {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if !c.WantsMore() {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	for i := 1; i <= 10; i++ {
 		c.Continues = i < 10
-		err := c.ReplyTest10("Reply number " + strconv.Itoa(i))
+		err := c.ReplyTest10(ctx, "Reply number "+strconv.Itoa(i))
 		if err != nil {
 			return err
 		}
@@ -542,38 +546,38 @@ func (t *test) Test10(c orgvarlinkcertification.VarlinkCall, client_id_ string, 
 	return nil
 }
 
-func (t *test) Test11(c orgvarlinkcertification.VarlinkCall, client_id_ string, last_more_replies_ []string) error {
+func (t *test) Test11(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string, last_more_replies_ []string) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	if len(last_more_replies_) != 10 {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	if !c.IsOneway() {
-		return c.ReplyCertificationError(nil, nil)
+		return c.ReplyCertificationError(ctx, nil, nil)
 	}
 
 	for i := 1; i <= 10; i++ {
 		if last_more_replies_[i] != "Reply number "+strconv.Itoa(i) {
-			return c.ReplyCertificationError(nil, nil)
+			return c.ReplyCertificationError(ctx, nil, nil)
 		}
 	}
 
-	return c.ReplyTest11()
+	return c.ReplyTest11(ctx)
 }
 
-func (t *test) End(c orgvarlinkcertification.VarlinkCall, client_id_ string) error {
+func (t *test) End(ctx context.Context, c orgvarlinkcertification.VarlinkCall, client_id_ string) error {
 	if t.Client(client_id_) == nil {
-		return c.ReplyClientIdError()
+		return c.ReplyClientIdError(ctx)
 	}
 
 	t.RemoveClient(client_id_)
-	return c.ReplyEnd(true)
+	return c.ReplyEnd(ctx, true)
 }
 
-func run_server(address string) {
+func run_server(ctx context.Context, address string) {
 	t := test{
 		clients: make(map[string]*client),
 	}
@@ -590,7 +594,7 @@ func run_server(address string) {
 	}
 
 	s.RegisterInterface(orgvarlinkcertification.VarlinkNew(&t))
-	err = s.Listen(address, 0)
+	err = s.Listen(ctx, address, 0)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -610,10 +614,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	if client {
-		run_client(address)
+		run_client(ctx, address)
 		return
 	}
 
-	run_server(address)
+	run_server(ctx, address)
 }

--- a/varlink/bridge.go
+++ b/varlink/bridge.go
@@ -3,11 +3,12 @@
 package varlink
 
 import (
-	"bufio"
 	"io"
 	"net"
 	"os"
 	"os/exec"
+
+	"github.com/varlink/go/varlink/internal/ctxio"
 )
 
 type PipeCon struct {
@@ -33,8 +34,6 @@ func (p PipeCon) Close() error {
 
 // NewBridgeWithStderr returns a new connection with the given bridge.
 func NewBridgeWithStderr(bridge string, stderr io.Writer) (*Connection, error) {
-	//var err error
-
 	c := Connection{}
 	cmd := exec.Command("sh", "-c", bridge)
 	cmd.Stderr = stderr
@@ -46,10 +45,8 @@ func NewBridgeWithStderr(bridge string, stderr io.Writer) (*Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.conn = PipeCon{nil, cmd, &r, &w}
+	c.conn = ctxio.NewConn(PipeCon{nil, cmd, &r, &w})
 	c.address = ""
-	c.Reader = bufio.NewReader(r)
-	c.Writer = bufio.NewWriter(w)
 
 	err = cmd.Start()
 	if err != nil {

--- a/varlink/internal/ctxio/conn.go
+++ b/varlink/internal/ctxio/conn.go
@@ -1,0 +1,111 @@
+package ctxio
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"time"
+)
+
+// Conn wraps net.Conn with context aware functionality.
+type Conn struct {
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+// NewConn creates a new context aware Conn.
+func NewConn(c net.Conn) *Conn {
+	return &Conn{
+		conn:   c,
+		reader: bufio.NewReader(c),
+	}
+}
+
+type wret struct {
+	n   int
+	err error
+}
+
+type rret struct {
+	val []byte
+	err error
+}
+
+// aLongTimeAgo is a time in the past that indicates a connection should
+// immediately time out.
+var aLongTimeAgo = time.Unix(1, 0)
+
+// Close releases the Conns resources.
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
+// Write writes to the underlying connection.
+// It is not safe for concurrent use with itself.
+func (c *Conn) Write(ctx context.Context, buf []byte) (int, error) {
+	// Enable immediate connection cancelation via context by using the context's
+	// deadline and also setting a deadline in the past if/when the context is
+	// canceled. This pattern courtesy of @acln from #networking on Gophers Slack.
+	dl, _ := ctx.Deadline()
+	if err := c.conn.SetWriteDeadline(dl); err != nil {
+		return 0, err
+	}
+
+	ch := make(chan wret, 1)
+	go func() {
+		n, err := c.conn.Write(buf)
+		ch <- wret{n, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Set deadling to unblock pending Write.
+		if err := c.conn.SetWriteDeadline(aLongTimeAgo); err != nil {
+			return 0, err
+		}
+		// Wait for goroutine to exit, throwing away the error.
+		<-ch
+		// Reset deadline again.
+		if err := c.conn.SetWriteDeadline(time.Time{}); err != nil {
+			return 0, err
+		}
+		return 0, ctx.Err()
+	case ret := <-ch:
+		return ret.n, ret.err
+	}
+}
+
+// ReadBytes reads from the connection until the bytes are found.
+// It is not safe for concurrent use with itself.
+func (c *Conn) ReadBytes(ctx context.Context, delim byte) ([]byte, error) {
+	// Enable immediate connection cancelation via context by using the context's
+	// deadline and also setting a deadline in the past if/when the context is
+	// canceled. This pattern courtesy of @acln from #networking on Gophers Slack.
+	dl, _ := ctx.Deadline()
+	if err := c.conn.SetReadDeadline(dl); err != nil {
+		return nil, err
+	}
+
+	ch := make(chan rret, 1)
+	go func() {
+		out, err := c.reader.ReadBytes(delim)
+		ch <- rret{out, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Set deadling to unblock pending Write.
+		if err := c.conn.SetReadDeadline(aLongTimeAgo); err != nil {
+			return nil, err
+		}
+		// Wait for goroutine to exit, throwing away the error.
+		<-ch
+		// Reset deadline again.
+		if err := c.conn.SetReadDeadline(time.Time{}); err != nil {
+			return nil, err
+		}
+		return nil, ctx.Err()
+	case ret := <-ch:
+		return ret.val, ret.err
+	}
+}

--- a/varlink/internal/ctxio/conn_test.go
+++ b/varlink/internal/ctxio/conn_test.go
@@ -1,0 +1,114 @@
+package ctxio_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/varlink/go/varlink/internal/ctxio"
+)
+
+func TestConn(t *testing.T) {
+	l, err := net.Listen("tcp", ":")
+	if err != nil {
+		t.Fatalf("Unexpected error creating a listener: %v", err)
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+
+		rd := bufio.NewReader(c)
+		req, err := rd.ReadBytes('\n')
+		if err != nil {
+			t.Errorf("Failed to execute readFunc: %v", err)
+			return
+		}
+
+		_, err = c.Write(append([]byte("Request received: "), req...))
+		if err != nil {
+			t.Errorf("Failed to execute writeFunc: %v", err)
+			return
+		}
+	}()
+
+	c, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to dial server: %v", err)
+	}
+
+	ctxC := ctxio.NewConn(c)
+
+	_, err = ctxC.Write(context.Background(), []byte("hello world\n"))
+	if err != nil {
+		t.Fatalf("Failed to write request: %v", err)
+	}
+
+	ret, err := ctxC.ReadBytes(context.Background(), '\n')
+	if err != nil {
+		t.Fatalf("Failed to read reply: %v", err)
+	}
+
+	want := []byte("Request received: hello world\n")
+	if !bytes.Equal(ret, want) {
+		t.Fatalf("Unexpected response: wanted %q, got %q", string(want), string(ret))
+	}
+
+	err = ctxC.Close()
+	if err != nil {
+		t.Fatalf("Failed to close ctx connection: %v", err)
+	}
+
+	err = l.Close()
+	if err != nil {
+		t.Fatalf("Failed to close listener: %v", err)
+	}
+
+	wg.Wait()
+}
+
+func TestBlockingWrite(t *testing.T) {
+	cl, _ := net.Pipe()
+
+	ctxC := ctxio.NewConn(cl)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(time.Millisecond)
+		cancel()
+	}()
+	_, err := ctxC.Write(ctx, []byte("hello world\n"))
+	if err == nil {
+		t.Fatal("Unexpectedly did not error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Got unexpected error: %T, %s", err, err)
+	}
+}
+
+func TestBlockingRead(t *testing.T) {
+	cl, _ := net.Pipe()
+
+	ctxC := ctxio.NewConn(cl)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(time.Millisecond)
+		cancel()
+	}()
+	_, err := ctxC.ReadBytes(ctx, '\n')
+	if err == nil {
+		t.Fatal("Unexpectedly did not error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Got unexpected error: %T, %s", err, err)
+	}
+}

--- a/varlink/internal/ctxio/conn_test.go
+++ b/varlink/internal/ctxio/conn_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -90,7 +89,7 @@ func TestBlockingWrite(t *testing.T) {
 	if err == nil {
 		t.Fatal("Unexpectedly did not error")
 	}
-	if !errors.Is(err, context.Canceled) {
+	if err != context.Canceled {
 		t.Fatalf("Got unexpected error: %T, %s", err, err)
 	}
 }
@@ -108,7 +107,7 @@ func TestBlockingRead(t *testing.T) {
 	if err == nil {
 		t.Fatal("Unexpectedly did not error")
 	}
-	if !errors.Is(err, context.Canceled) {
+	if err != context.Canceled {
 		t.Fatalf("Got unexpected error: %T, %s", err, err)
 	}
 }

--- a/varlink/listen_1.10.go
+++ b/varlink/listen_1.10.go
@@ -1,0 +1,12 @@
+// +build !go1.11
+
+package varlink
+
+import (
+	"context"
+	"net"
+)
+
+func listen(ctx context.Context, network, address string) (net.Listener, error) {
+	return net.Listen(network, address)
+}

--- a/varlink/listen_1.11.go
+++ b/varlink/listen_1.11.go
@@ -1,0 +1,13 @@
+// +build go1.11
+
+package varlink
+
+import (
+	"context"
+	"net"
+)
+
+func listen(ctx context.Context, network, address string) (net.Listener, error) {
+	var lc net.ListenConfig
+	return lc.Listen(ctx, network, address)
+}

--- a/varlink/orgvarlinkservice.go
+++ b/varlink/orgvarlinkservice.go
@@ -1,5 +1,7 @@
 package varlink
 
+import "context"
+
 // The requested interface was not found.
 type InterfaceNotFound struct {
 	Interface string `json:"interface"`
@@ -37,42 +39,42 @@ func (e InvalidParameter) Error() string {
 	return "org.varlink.service.InvalidParameter"
 }
 
-func doReplyError(c *Call, name string, parameters interface{}) error {
-	return c.sendMessage(&serviceReply{
+func doReplyError(ctx context.Context, c *Call, name string, parameters interface{}) error {
+	return c.sendMessage(ctx, &serviceReply{
 		Error:      name,
 		Parameters: parameters,
 	})
 }
 
-// ReplyInterfaceNotFound sends a org.varlink.service errror reply to this method call
-func (c *Call) ReplyInterfaceNotFound(interfaceA string) error {
+// ReplyInterfaceNotFound sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyInterfaceNotFound(ctx context.Context, interfaceA string) error {
 	var out InterfaceNotFound
 	out.Interface = interfaceA
-	return doReplyError(c, "org.varlink.service.InterfaceNotFound", &out)
+	return doReplyError(ctx, c, "org.varlink.service.InterfaceNotFound", &out)
 }
 
-// ReplyMethodNotFound sends a org.varlink.service errror reply to this method call
-func (c *Call) ReplyMethodNotFound(method string) error {
+// ReplyMethodNotFound sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyMethodNotFound(ctx context.Context, method string) error {
 	var out MethodNotFound
 	out.Method = method
-	return doReplyError(c, "org.varlink.service.MethodNotFound", &out)
+	return doReplyError(ctx, c, "org.varlink.service.MethodNotFound", &out)
 }
 
-// ReplyMethodNotImplemented sends a org.varlink.service errror reply to this method call
-func (c *Call) ReplyMethodNotImplemented(method string) error {
+// ReplyMethodNotImplemented sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyMethodNotImplemented(ctx context.Context, method string) error {
 	var out MethodNotImplemented
 	out.Method = method
-	return doReplyError(c, "org.varlink.service.MethodNotImplemented", &out)
+	return doReplyError(ctx, c, "org.varlink.service.MethodNotImplemented", &out)
 }
 
-// ReplyInvalidParameter sends a org.varlink.service errror reply to this method call
-func (c *Call) ReplyInvalidParameter(parameter string) error {
+// ReplyInvalidParameter sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyInvalidParameter(ctx context.Context, parameter string) error {
 	var out InvalidParameter
 	out.Parameter = parameter
-	return doReplyError(c, "org.varlink.service.InvalidParameter", &out)
+	return doReplyError(ctx, c, "org.varlink.service.InvalidParameter", &out)
 }
 
-func (c *Call) replyGetInfo(vendor string, product string, version string, url string, interfaces []string) error {
+func (c *Call) replyGetInfo(ctx context.Context, vendor string, product string, version string, url string, interfaces []string) error {
 	var out struct {
 		Vendor     string   `json:"vendor,omitempty"`
 		Product    string   `json:"product,omitempty"`
@@ -85,37 +87,37 @@ func (c *Call) replyGetInfo(vendor string, product string, version string, url s
 	out.Version = version
 	out.URL = url
 	out.Interfaces = interfaces
-	return c.Reply(&out)
+	return c.Reply(ctx, &out)
 }
 
-func (c *Call) replyGetInterfaceDescription(description string) error {
+func (c *Call) replyGetInterfaceDescription(ctx context.Context, description string) error {
 	var out struct {
 		Description string `json:"description,omitempty"`
 	}
 	out.Description = description
-	return c.Reply(&out)
+	return c.Reply(ctx, &out)
 }
 
-func (s *Service) orgvarlinkserviceDispatch(c Call, methodname string) error {
+func (s *Service) orgvarlinkserviceDispatch(ctx context.Context, c Call, methodname string) error {
 	switch methodname {
 	case "GetInfo":
-		return s.getInfo(c)
+		return s.getInfo(ctx, c)
 	case "GetInterfaceDescription":
 		var in struct {
 			Interface string `json:"interface"`
 		}
 		err := c.GetParameters(&in)
 		if err != nil {
-			return c.ReplyInvalidParameter("parameters")
+			return c.ReplyInvalidParameter(ctx, "parameters")
 		}
-		return s.getInterfaceDescription(c, in.Interface)
+		return s.getInterfaceDescription(ctx, c, in.Interface)
 
 	default:
-		return c.ReplyMethodNotFound(methodname)
+		return c.ReplyMethodNotFound(ctx, methodname)
 	}
 }
 
-func (s *orgvarlinkserviceInterface) VarlinkDispatch(call Call, methodname string) error {
+func (s *orgvarlinkserviceInterface) VarlinkDispatch(ctx context.Context, call Call, methodname string) error {
 	return nil
 }
 

--- a/varlink/resolver.go
+++ b/varlink/resolver.go
@@ -1,5 +1,7 @@
 package varlink
 
+import "context"
+
 // ResolverAddress is the well-known address of the varlink interface resolver,
 // it translates varlink interface names to varlink service addresses.
 const ResolverAddress = "unix:/run/org.varlink.resolver"
@@ -11,7 +13,7 @@ type Resolver struct {
 }
 
 // Resolve resolves a varlink interface name to a varlink address.
-func (r *Resolver) Resolve(iface string) (string, error) {
+func (r *Resolver) Resolve(ctx context.Context, iface string) (string, error) {
 	type request struct {
 		Interface string `json:"interface"`
 	}
@@ -25,7 +27,7 @@ func (r *Resolver) Resolve(iface string) (string, error) {
 	}
 
 	var rep reply
-	err := r.conn.Call("org.varlink.resolver.Resolve", &request{Interface: iface}, &rep)
+	err := r.conn.Call(ctx, "org.varlink.resolver.Resolve", &request{Interface: iface}, &rep)
 	if err != nil {
 		return "", err
 	}
@@ -34,7 +36,7 @@ func (r *Resolver) Resolve(iface string) (string, error) {
 }
 
 // GetInfo requests information about the resolver.
-func (r *Resolver) GetInfo(vendor *string, product *string, version *string, url *string, interfaces *[]string) error {
+func (r *Resolver) GetInfo(ctx context.Context, vendor *string, product *string, version *string, url *string, interfaces *[]string) error {
 	type reply struct {
 		Vendor     string
 		Product    string
@@ -44,7 +46,7 @@ func (r *Resolver) GetInfo(vendor *string, product *string, version *string, url
 	}
 
 	var rep reply
-	err := r.conn.Call("org.varlink.resolver.GetInfo", nil, &rep)
+	err := r.conn.Call(ctx, "org.varlink.resolver.GetInfo", nil, &rep)
 	if err != nil {
 		return err
 	}
@@ -74,12 +76,12 @@ func (r *Resolver) Close() error {
 }
 
 // NewResolver returns a new resolver connected to the given address.
-func NewResolver(address string) (*Resolver, error) {
+func NewResolver(ctx context.Context, address string) (*Resolver, error) {
 	if address == "" {
 		address = ResolverAddress
 	}
 
-	c, err := NewConnection(address)
+	c, err := NewConnection(ctx, address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I've aimed to keep backwards compatibility where possible, but I'd be happy to remove the functions that don't take a context if that is alright.

## varlink/internal: add ctxio package

The ctxio package exposes a Conn
which can support calling Read and
Write with a context.

## varlink: add deep context integration

Varlink uses the ctxio Conn to support
writing and reading while allowing
operations to be cancelled via the
context.

Fixes #15