### PR TITLE
Add upgrade method

### DIFF
--- a/varlink/call.go
+++ b/varlink/call.go
@@ -8,15 +8,11 @@ import (
 	"strings"
 )
 
-type WriterContext interface {
-	Write(context.Context, []byte) (int, error)
-}
-
 // Call is a method call retrieved by a Service. The connection from the
 // client can be terminated by returning an error from the call instead
 // of sending a reply or error reply.
 type Call struct {
-	Conn      WriterContext
+	Conn      ReadWriterContext
 	Request   *[]byte
 	In        *serviceCall
 	Continues bool

--- a/varlink/connection.go
+++ b/varlink/connection.go
@@ -79,7 +79,7 @@ func (e *Error) Error() string {
 // ReadWriterContext describes the capabilities of the
 // underlying varlink connection.
 type ReadWriterContext interface {
-	WriterContext
+	Write(context.Context, []byte) (int, error)
 	Read(context.Context, []byte) (int, error)
 	ReadBytes(ctx context.Context, delim byte) ([]byte, error)
 }

--- a/varlink/connection.go
+++ b/varlink/connection.go
@@ -76,6 +76,14 @@ func (e *Error) Error() string {
 	return e.Name
 }
 
+// ReadWriterContext describes the capabilities of the
+// underlying varlink connection.
+type ReadWriterContext interface {
+	WriterContext
+	Read(context.Context, []byte) (int, error)
+	ReadBytes(ctx context.Context, delim byte) ([]byte, error)
+}
+
 // Connection is a connection from a client to a service.
 type Connection struct {
 	io.Closer
@@ -236,6 +244,24 @@ func (c *Connection) GetInfo(ctx context.Context, vendor *string, product *strin
 	}
 
 	return nil
+}
+
+// Upgrade attempts to upgrade the connection using the provided method and parameters.
+// If successful, the connection cannot be reused later, and must be closed.
+func (c *Connection) Upgrade(ctx context.Context, method string, parameters interface{}) (func(context.Context, interface{}) (uint64, ReadWriterContext, error), error) {
+	reply, err := c.Send(ctx, method, parameters, Upgrade)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context, out interface{}) (uint64, ReadWriterContext, error) {
+		flags, err := reply(ctx, out)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		return flags, c.conn, nil
+	}, nil
 }
 
 // Close terminates the connection.

--- a/varlink/service.go
+++ b/varlink/service.go
@@ -76,11 +76,10 @@ func (s *Service) getInterfaceDescription(ctx context.Context, c Call, name stri
 	return c.replyGetInterfaceDescription(ctx, description)
 }
 
-func (s *Service) HandleMessage(ctx context.Context, conn WriterContext, request []byte) error {
+func (s *Service) HandleMessage(ctx context.Context, conn ReadWriterContext, request []byte) error {
 	var in serviceCall
 
 	err := json.Unmarshal(request, &in)
-
 	if err != nil {
 		return err
 	}
@@ -138,7 +137,7 @@ func (s *Service) handleConnection(ctx context.Context, conn net.Conn, wg *sync.
 		err = s.HandleMessage(ctx, ctxConn, request[:len(request)-1])
 		if err != nil {
 			// FIXME: report error
-			//fmt.Fprintf(os.Stderr, "handleMessage: %v", err)
+			// fmt.Fprintf(os.Stderr, "handleMessage: %v", err)
 			break
 		}
 	}

--- a/varlink/varlink_test.go
+++ b/varlink/varlink_test.go
@@ -17,10 +17,18 @@ func expect(t *testing.T, expected string, returned string) {
 	}
 }
 
-type writerContextFunc func(context.Context, []byte) (int, error)
+type readWriterContextFunc func(context.Context, []byte) (int, error)
 
-func (wcf writerContextFunc) Write(ctx context.Context, in []byte) (int, error) {
+func (wcf readWriterContextFunc) Write(ctx context.Context, in []byte) (int, error) {
 	return wcf(ctx, in)
+}
+
+func (wcf readWriterContextFunc) Read(context.Context, []byte) (int, error) {
+	return 0, nil
+}
+
+func (wcf readWriterContextFunc) ReadBytes(context.Context, byte) ([]byte, error) {
+	return nil, nil
 }
 
 func TestService(t *testing.T) {
@@ -32,7 +40,7 @@ func TestService(t *testing.T) {
 	)
 
 	t.Run("ZeroMessage", func(t *testing.T) {
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			return 0, nil
 		})
 		if err := service.HandleMessage(context.Background(), wf, []byte{0}); err == nil {
@@ -41,7 +49,7 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("InvalidJson", func(t *testing.T) {
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			return 0, nil
 		})
 		msg := []byte(`{"method":"foo.GetInterfaceDescription" fdgdfg}`)
@@ -52,7 +60,7 @@ func TestService(t *testing.T) {
 
 	t.Run("WrongInterface", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -65,7 +73,7 @@ func TestService(t *testing.T) {
 	})
 	t.Run("InvalidMethod", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -79,7 +87,7 @@ func TestService(t *testing.T) {
 
 	t.Run("WrongMethod", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -93,7 +101,7 @@ func TestService(t *testing.T) {
 
 	t.Run("GetInterfaceDescriptionNullParameters", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -107,7 +115,7 @@ func TestService(t *testing.T) {
 
 	t.Run("GetInterfaceDescriptionNoInterface", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -121,7 +129,7 @@ func TestService(t *testing.T) {
 
 	t.Run("GetInterfaceDescriptionWrongInterface", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -135,7 +143,7 @@ func TestService(t *testing.T) {
 
 	t.Run("GetInterfaceDescription", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -149,7 +157,7 @@ func TestService(t *testing.T) {
 
 	t.Run("GetInfo", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -206,6 +214,7 @@ func (s *VarlinkInterface) VarlinkDispatch(ctx context.Context, call Call, metho
 
 	return call.ReplyMethodNotImplemented(ctx, methodname)
 }
+
 func (s *VarlinkInterface) VarlinkGetName() string {
 	return `org.example.test`
 }
@@ -230,7 +239,7 @@ func TestMoreService(t *testing.T) {
 
 	t.Run("MethodNotImplemented", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -244,7 +253,7 @@ func TestMoreService(t *testing.T) {
 
 	t.Run("PingError", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})
@@ -257,7 +266,7 @@ func TestMoreService(t *testing.T) {
 	})
 	t.Run("MoreTest", func(t *testing.T) {
 		var written []byte
-		wf := writerContextFunc(func(ctx context.Context, in []byte) (int, error) {
+		wf := readWriterContextFunc(func(ctx context.Context, in []byte) (int, error) {
 			written = append(written, in...)
 			return len(in), nil
 		})


### PR DESCRIPTION
## varlink: add Upgrade method to connection

Upgrade can be used to upgrade a connection for sending
data. The connection cannot be reused after upgrading.

## cmd/varlink-go-interface-generator: Generate Upgrade

Upgrade can be used to get access to the raw underlying
connection with the varlink server.

Fixes #18