### PR TITLE
connection: Enable access to underlying net.Conn

### DIFF
--- a/varlink/connection.go
+++ b/varlink/connection.go
@@ -84,6 +84,13 @@ type ReadWriterContext interface {
 	ReadBytes(ctx context.Context, delim byte) ([]byte, error)
 }
 
+// GetNetConn allows access to the underlying net.Conn (where one exists)
+// You shouldn't use this for I/O - but might use it to do things like access
+// peer credentials on a unix socket
+type GetNetConn interface {
+	NetConn() net.Conn
+}
+
 // Connection is a connection from a client to a service.
 type Connection struct {
 	io.Closer

--- a/varlink/internal/ctxio/conn.go
+++ b/varlink/internal/ctxio/conn.go
@@ -35,6 +35,10 @@ type rret struct {
 // immediately time out.
 var aLongTimeAgo = time.Unix(1, 0)
 
+func (c *Conn) NetConn() net.Conn {
+	return c.conn
+}
+
 // Close releases the Conns resources.
 func (c *Conn) Close() error {
 	return c.conn.Close()


### PR DESCRIPTION
This allows applications to do authenticatication via Unix SO_PEERCREDS,
for example